### PR TITLE
Don't re-define c++ round() method

### DIFF
--- a/cores/common/arduino/src/wiring/wiring_compat.h
+++ b/cores/common/arduino/src/wiring/wiring_compat.h
@@ -22,7 +22,9 @@ extern "C" {
 #define voidFuncPtrArg		voidFuncPtrParam
 
 // Additional Arduino compatibility macros
+#ifndef __cplusplus
 #define round(x)				   ((x) >= 0 ? (long)((x) + 0.5) : (long)((x) - 0.5))
+#endif
 #define digitalPinToInterrupt(pin) (pin)
 
 // FreeRTOS utilities


### PR DESCRIPTION
I've recently been hit by the same compilation error as described [here](https://github.com/esphome/issues/issues/6124).
The easiest way to solve this is to only define this macro if the header is included from within pure C code.

Works for me :)
